### PR TITLE
Add number of manually invited users to constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+node_modules/
 npm-debug.log
 previouslyInvited.json
 previouslyInvitedDev.json

--- a/constants.js
+++ b/constants.js
@@ -8,14 +8,16 @@ const devConstants = {
     PREVIOUS_INVITES_FILE: './previouslyInvitedDev.json',
     TYPEFORM_FORM_ID: 'p5DhOL',
     TYPEFORM_EMAIL_FIELD: 'email_37507879',
-    TYPEFORM_TWITTER_FIELD: 'textfield_44354349'
+    TYPEFORM_TWITTER_FIELD: 'textfield_44354349',
+    MANUALLY_INVITED: 0
 }
 
 const prodConstants = {
     PREVIOUS_INVITES_FILE: './previouslyInvitedProd.json',
     TYPEFORM_FORM_ID: 'JYeqCl',
     TYPEFORM_EMAIL_FIELD: 'email_37513365',
-    TYPEFORM_TWITTER_FIELD: 'textfield_37512157'
+    TYPEFORM_TWITTER_FIELD: 'textfield_37512157',
+    MANUALLY_INVITED: 50 // People who signed up on the form pre-automation and were invited manually
 }
 
 const constants = process.env['NODE_ENV'] === 'production' ? prodConstants : devConstants

--- a/constants.js
+++ b/constants.js
@@ -9,7 +9,7 @@ const devConstants = {
     TYPEFORM_FORM_ID: 'p5DhOL',
     TYPEFORM_EMAIL_FIELD: 'email_37507879',
     TYPEFORM_TWITTER_FIELD: 'textfield_44354349',
-    MANUALLY_INVITED: 0
+    MANUALLY_INVITED: 8
 }
 
 const prodConstants = {

--- a/get-invitees.js
+++ b/get-invitees.js
@@ -6,14 +6,16 @@ const request = require('request'),
       TYPEFORM_FORM_ID = constants.TYPEFORM_FORM_ID,
       TYPEFORM_EMAIL_FIELD = constants.TYPEFORM_EMAIL_FIELD,
       TYPEFORM_TWITTER_FIELD = constants.TYPEFORM_TWITTER_FIELD,
+      MANUALLY_INVITED = constants.MANUALLY_INVITED,
       getPreviouslyInvited = require('./helpers').getPreviouslyInvited
 
 function getInvitees(callback) {
     console.log('getting latest responses from Typeform...')
     // Get an offset because TypeForm only returns 1,000 results max
     // So when over 1,000 have signed up, we need only most recent results
+    // Offset should include the number of users that were manually added before automation
     const previouslyInvited = getPreviouslyInvited()
-    const offset = previouslyInvited.length
+    const offset = previouslyInvited.length + MANUALLY_INVITED
 
     request({
         url: 'https://api.typeform.com/v1/form/' + TYPEFORM_FORM_ID,


### PR DESCRIPTION
The Typeform we will be using to invite new members has already received 50 responses from people signing up for NYCEDU. Those folks have already been invited to the Slack team manually, and we do not want to send them invites again.

This means that the first person who fills out the form after we're deployed in production will actually be response number 51. So we want to send typeform an offset of 50. This would be computed as the constant number of manually invited users (50) plus the length of the `previouslyInvitedProd.json` file (0).

If more people join between now and the production deploy, the constant can be updated again.