### PR TITLE
Separate API keys for staging and dev

### DIFF
--- a/api-keys.js
+++ b/api-keys.js
@@ -4,29 +4,30 @@
 // To export the prodKeys, the NODE_ENV environment variable
 // must be set to 'production' in bash_profile
 
-const env = process.env,
-    _ = require('lodash')
+const env = process.env
 
-const baseKeys = {
-    SLACK_TOKEN: env['SLACK_TOKEN'],
+const devKeys = {
+    TYPEFORM_TOKEN: env['DEV_TYPEFORM_TOKEN'],
+    SLACK_TOKEN: env['DEV_SLACK_TOKEN'],
     twitterKeys: {
-        consumer_key: env['NYCEDU_TWITTER_CONSUMER_KEY'],
-        consumer_secret: env['NYCEDU_TWITTER_CONSUMER_SECRET'],
-        access_token_key: env['NYCEDU_TWITTER_ACCESS_TOKEN'],
-        access_token_secret: env['NYCEDU_TWITTER_ACCESS_TOKEN_SECRET']
+        consumer_key: env['DEV_NYCEDU_TWITTER_CONSUMER_KEY'],
+        consumer_secret: env['DEV_NYCEDU_TWITTER_CONSUMER_SECRET'],
+        access_token_key: env['DEV_NYCEDU_TWITTER_ACCESS_TOKEN'],
+        access_token_secret: env['DEV_NYCEDU_TWITTER_ACCESS_TOKEN_SECRET']
     }
 }
 
-const devKeys = {
-    TYPEFORM_TOKEN: env['TYPEFORM_TOKEN']
-}
-
 const prodKeys = {
-    TYPEFORM_TOKEN: env['PROD_TYPEFORM_TOKEN']
+    TYPEFORM_TOKEN: env['PROD_TYPEFORM_TOKEN'],
+    SLACK_TOKEN: env['PROD_SLACK_TOKEN'],
+    twitterKeys: {
+        consumer_key: env['PROD_NYCEDU_TWITTER_CONSUMER_KEY'],
+        consumer_secret: env['PROD_NYCEDU_TWITTER_CONSUMER_SECRET'],
+        access_token_key: env['PROD_NYCEDU_TWITTER_ACCESS_TOKEN'],
+        access_token_secret: env['PROD_NYCEDU_TWITTER_ACCESS_TOKEN_SECRET']
+    }
 }
 
-const envKeys = env['NODE_ENV'] === 'production' ? prodKeys : devKeys
-
-const apiKeys = _.extend({}, baseKeys, envKeys)
+const apiKeys = env['NODE_ENV'] === 'production' ? prodKeys : devKeys
 
 module.exports = apiKeys


### PR DESCRIPTION
There will be a staging heroku app and a production app, and along with that I would like to have
separate staging accounts (and API keys) to test our Twitter, Typeform, and Slack integrations.

This commit more clearly separates out the development and production API keys so that local and
staging code will only use the staging Twitter / Typeform / Slack accounts. I am still getting
all of the keys, so there is not a complete set for staging and production at the moment. This
should be sorted out in a few days at the latest.

Once I have all of the keys for both dev and production I can share them with NYCEDU admins and
anyone else who wants to develop these tools locally. We should hold off on merging this change
until I have shared all of the keys. To run locally, you will need to update your environment
variables after I share the complete set of keys.

Also, to run postgres locally you will need a DATABASE_URL environment variable. Heroku generates
this automatically for the staging and production servers. Locally you can just use something like
`postgres:///my_db_name` and then create your users table there (schema / seed files to come!).