### PR TITLE
Add tests for retrieving constants and keys by environment

### DIFF
--- a/test/api-keys-test.js
+++ b/test/api-keys-test.js
@@ -1,0 +1,41 @@
+const path = require("path"),
+    apiKeysFilePath = path.join(__dirname, '..', 'api-keys.js')
+
+describe("api-keys.js", function () {
+    beforeEach(function () {
+        process.env = {
+            DEV_SLACK_TOKEN: 'fake dev slack token',
+            PROD_SLACK_TOKEN: 'fake prod slack token',
+            DEV_NYCEDU_TWITTER_ACCESS_TOKEN: 'fake dev twitter token',
+            PROD_NYCEDU_TWITTER_ACCESS_TOKEN: 'fake prod twitter token'
+        }
+    })
+    describe("not in production", function () {
+        beforeEach(function () {
+            process.env.NODE_ENV = 'development'
+            this.apiKeys = require('../api-keys')
+        })
+
+        it("requires the expected apiKeys with the expected object shape", function () {
+            expect(this.apiKeys.SLACK_TOKEN).to.equal('fake dev slack token')
+            expect(this.apiKeys.twitterKeys.access_token_key).to.equal('fake dev twitter token')
+        })
+    })
+
+    describe("in production", function () {
+        beforeEach(function () {
+            process.env.NODE_ENV = 'production'
+            this.apiKeys = require('../api-keys')
+        })
+
+        it("requires the expected apiKeys with the expected object shape", function () {
+            expect(this.apiKeys.SLACK_TOKEN).to.equal('fake prod slack token')
+            expect(this.apiKeys.twitterKeys.access_token_key).to.equal('fake prod twitter token')
+        })
+    })
+
+    afterEach(function () {
+        // need to do this or else node will reuse the apiKeys.js in memory
+        delete require.cache[apiKeysFilePath]
+    })
+})

--- a/test/constants-test.js
+++ b/test/constants-test.js
@@ -1,0 +1,37 @@
+const path = require("path"),
+    constantsFilePath = path.join(__dirname, '..', 'constants.js')
+
+describe("constants.js", function () {
+    describe("not in production", function () {
+        beforeEach(function () {
+            process.env.NODE_ENV = 'development'
+            this.constants = require('../constants')
+        })
+
+        it("requires the expected constants", function () {
+            expect(this.constants.TYPEFORM_FORM_ID).to.equal('p5DhOL')
+            expect(this.constants.TYPEFORM_EMAIL_FIELD).to.equal('email_37507879')
+            expect(this.constants.TYPEFORM_TWITTER_FIELD).to.equal('textfield_44354349')
+            expect(this.constants.MANUALLY_INVITED).to.equal(8)
+        })
+    })
+
+    describe("in production", function () {
+        beforeEach(function () {
+            process.env.NODE_ENV = 'production'
+            this.constants = require('../constants')
+        })
+
+        it("requires the expected constants", function () {
+            expect(this.constants.TYPEFORM_FORM_ID).to.equal('JYeqCl')
+            expect(this.constants.TYPEFORM_EMAIL_FIELD).to.equal('email_37513365')
+            expect(this.constants.TYPEFORM_TWITTER_FIELD).to.equal('textfield_37512157')
+            expect(this.constants.MANUALLY_INVITED).to.equal(50)
+        })
+    })
+
+    afterEach(function () {
+        // need to do this or else node will reuse the constants.js in memory
+        delete require.cache[constantsFilePath]
+    })
+})


### PR DESCRIPTION
Just making sure that when we `require` constants or api-keys, the logic in those files correctly exports the constants and keys for the environment. To make the tests work, I needed an `afterEach` that removes the node.js require cache for that file (otherwise it won't actually require again for subsequent tests). I'm not sure if that is really cool or really hacky. Both?