### PR TITLE
Rename users table form_submissions

### DIFF
--- a/bin/create-tables
+++ b/bin/create-tables
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-// Creates a users table and populates it with responses already submitted to Typeform
+// Creates a form_submissions table and populates it with responses already submitted to Typeform
 // This is to be used when setting up a local instance or environment for the first time
 
 // if running locally, you will first need to create a database
@@ -9,23 +9,23 @@
 
 const dbHelpers = require('../db-helpers'),
     typeformHelpers = require('../typeform-helpers'),
-    createUsersTable = dbHelpers.createUsersTable,
-    saveUsers = dbHelpers.saveUsers,
+    createFormSubmissionsTable = dbHelpers.createFormSubmissionsTable,
+    saveFormSubmissions = dbHelpers.saveFormSubmissions,
     getFromTypeform = typeformHelpers.getFromTypeform,
     parseResponses = typeformHelpers.parseResponses
 
-console.log("Creating users table...")
-createUsersTable( () => {
+console.log("Creating form_submissions table...")
+createFormSubmissionsTable( () => {
     console.log("Getting all past responses from Typeform...")
     getFromTypeform( {}, (error, response, body) => {
         if (error) {
             console.log("Error:", error)
         } else {
             console.log("Received data from Typeform.")
-            const users = parseResponses(JSON.parse(body))
-            
-            console.log("Saving past responses to users table...")
-            saveUsers(users, (result) => {
+            const submissions = parseResponses(JSON.parse(body))
+
+            console.log("Saving past responses to form_submissions table...")
+            saveFormSubmissions(submissions, (result) => {
                 console.log(result)
             })
         }

--- a/invite-and-follow-users.js
+++ b/invite-and-follow-users.js
@@ -4,9 +4,8 @@ const request = require('request'),
       path = require('path'),
       TOKEN = require('./api-keys').SLACK_TOKEN,
       dbHelpers = require('./db-helpers'),
-      getUserByEmail = dbHelpers.getUserByEmail,
-      getUserSubmission = dbHelpers.getUserSubmission,
-      saveUser = dbHelpers.saveUser,
+      getFormSubmission = dbHelpers.getFormSubmission,
+      saveFormSubmission = dbHelpers.saveFormSubmission,
       twitterFollowByScreenName = require('./twitter-follow-screen-name')
 
 function inviteAndFollowUsers(users) {
@@ -16,7 +15,7 @@ function inviteAndFollowUsers(users) {
             console.log("Invalid data for user, skipping:", user)
             return;
         }
-        getUserSubmission(user.email, user.dateSubmit, (result) => {
+        getFormSubmission(user.email, user.dateSubmit, (result) => {
             if (!result) {
                 console.log("New form submission:", user)
                 inviteUser(user)
@@ -46,12 +45,12 @@ function inviteUser(user) {
                 console.log('Error inviting ' + email + ': ' + error)
                 console.log(body)
                 if (body.error && ['already_invited', 'already_in_team', 'sent_recently'].indexOf(body.error) > -1) {
-                    saveUser(email, user.dateSubmit)
+                    saveFormSubmission(email, user.dateSubmit)
                 }
             } else {
                 console.log('Successfully invited ' + email)
                 console.log(body)
-                saveUser(email, user.dateSubmit)
+                saveFormSubmission(email, user.dateSubmit)
             }
     })
 }


### PR DESCRIPTION
Each row in the table has an email and a date_submit, with a unique constraint only on email and date_submit together. So this is really a table of form submissions, not a table of users. (A user's email could be in multiple rows).

Refactor table name and method names throughout the db methods. I left the term `user` in methods that acutally send invitations and follow people because at that point we are talking about a specific NYCEDU user.