### PR TITLE
Zapier code snippet for slack invites

### DIFF
--- a/zapier_slack.py
+++ b/zapier_slack.py
@@ -1,0 +1,11 @@
+email = input_data['email']
+print "Inviting {}...".format(email)
+url = 'https://slack.com/api/users.admin.invite'
+body = {
+    'token': '<your token here>',
+    'email': email,
+    'resend': True
+}
+res = requests.post(url, data = body)
+res.raise_for_status() # optional but good practice in case the call fails!
+output = {'text': res.text, 'json': res.json()}


### PR DESCRIPTION
This is the script we are using for the zapier integration. The slack token is not included here but can be pasted in.